### PR TITLE
Add ImportLdstr option as a temporary workaround for assembly conflict

### DIFF
--- a/Localizer/Configuration.cs
+++ b/Localizer/Configuration.cs
@@ -4,6 +4,8 @@ namespace Localizer
     {
         public bool AutoImport { get; set; } = true;
 
+        public bool ImportLdstr { get; set; } = true;
+
         public AutoImportType AutoImportType { get; set; } = AutoImportType.All;
 
         public bool ShowUI { get; set; } = true;

--- a/Localizer/Package/Import/CecilLdstrImporter.cs
+++ b/Localizer/Package/Import/CecilLdstrImporter.cs
@@ -34,7 +34,7 @@ namespace Localizer.Package.Import
             try
             {
                 var instance = Localizer.Kernel.Get<CecilLdstrImporter>();
-                if (!instance.Importing)
+                if (!instance.Importing || !Localizer.Config.ImportLdstr)
                 {
                     return;
                 }

--- a/Localizer/build.txt
+++ b/Localizer/build.txt
@@ -1,5 +1,5 @@
 author = Chireiden Team
-version = 1.5.0.12
+version = 1.5.0.13
 displayName = Localizer
 hideCode = true
 hideResources = false


### PR DESCRIPTION
Ldstr imported (Cecil edited) assembly leads to reference conflict for mods like `FargowiltasSouls` which interact with other mods.
`ThoriumModPlayer (Thorium_0) cannot be convert to ThoriumModPlayer (Thorium_1)` etc.
Add an option to disable the ldstr import as a temporary workaround.